### PR TITLE
Actually launch the server with the correct security group

### DIFF
--- a/lib/generators/lobot/templates/ci.rake
+++ b/lib/generators/lobot/templates/ci.rake
@@ -60,7 +60,8 @@ namespace :ci do
     server = aws_connection.servers.create(
       :image_id => 'ami-d4de25bd',
       :flavor_id =>  server_config['flavor_id'] || 'm1.large',
-      :key_name => ec2_key_pair_name
+      :key_name => ec2_key_pair_name,
+      :groups => [security_group_name]
     )
     server.wait_for { ready? }
     sleep 15 # Server ready? seems to mean 'almost ready'.  Sleep value is arbitrary at the moment


### PR DESCRIPTION
The launch script isn't actually using the security when it launches the server (even though it is setting the security group up correctly).
