### PR TITLE
Make JUnit Publisher optional

### DIFF
--- a/chef/cookbooks/pivotal_ci/recipes/jenkins_config.rb
+++ b/chef/cookbooks/pivotal_ci/recipes/jenkins_config.rb
@@ -37,10 +37,12 @@ node["jenkins"]["builds"].each do |build|
     source "jenkins-job-config.xml.erb"
     owner "jenkins"
     notifies :restart, "service[jenkins]"
+    junit_publisher = build['junit_publisher'].nil? ? true : build['junit_publisher']
     variables(
       :branch => build['branch'],
       :command => build['command'],
-      :repository => build['repository']
+      :repository => build['repository'],
+      :junit_publisher => junit_publisher
     )
   end
 end

--- a/chef/cookbooks/pivotal_ci/templates/default/jenkins-job-config.xml.erb
+++ b/chef/cookbooks/pivotal_ci/templates/default/jenkins-job-config.xml.erb
@@ -55,11 +55,13 @@
     </hudson.tasks.Shell>
   </builders>
   <publishers>
-    <hudson.tasks.junit.JUnitResultArchiver>
-      <testResults>spec/reports/*.xml</testResults>
-      <keepLongStdio>false</keepLongStdio>
-      <testDataPublishers/>
-    </hudson.tasks.junit.JUnitResultArchiver>
+    <% if @junit_publisher %>
+        <hudson.tasks.junit.JUnitResultArchiver>
+          <testResults>spec/reports/*.xml</testResults>
+          <keepLongStdio>false</keepLongStdio>
+          <testDataPublishers/>
+        </hudson.tasks.junit.JUnitResultArchiver>
+    <% end %>
   </publishers>
   <buildWrappers>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper>

--- a/lib/lobot/cli.rb
+++ b/lib/lobot/cli.rb
@@ -98,7 +98,8 @@ module Lobot
         "name" => name,
         "repository" => repository,
         "branch" => branch,
-        "command" => command
+        "command" => command,
+        "junit_publisher" => true
       }
       lobot_config.node_attributes = lobot_config.node_attributes.tap do |config|
         config.jenkins.builds << build unless config.jenkins.builds.include?(build)

--- a/spec/lib/lobot/cli_spec.rb
+++ b/spec/lib/lobot/cli_spec.rb
@@ -76,7 +76,8 @@ describe Lobot::CLI do
           "name" => "bob",
           "repository" => "http://github.com/mkocher/soloist.git",
           "command" => "script/ci_build.sh",
-          "branch" => "master"
+          "branch" => "master",
+          "junit_publisher" => true
         }]
       end
 
@@ -87,7 +88,8 @@ describe Lobot::CLI do
           "name" => "bob",
           "repository" => "http://github.com/mkocher/soloist.git",
           "command" => "script/ci_build.sh",
-          "branch" => "master"
+          "branch" => "master",
+          "junit_publisher" => true
         }]
       end
 


### PR DESCRIPTION
We added the ability to make enabling the "Publish JUnit test result report" post-build action optional so that we don't have to disable it every time we chef our CI box.
