### PR TITLE
Unversion hashie in gemspec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "chef/travis-cookbooks"]
 	path = chef/travis-cookbooks
-	url = https://github.com/pivotalexperimental/travis-cookbooks
+	url = git://github.com/travis-ci/travis-cookbooks.git

--- a/lobot.gemspec
+++ b/lobot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fog", "~> 1.6"
   s.add_dependency "ci_reporter", "~> 1.7"
   s.add_dependency "thor"
-  s.add_dependency "hashie", "~> 2.0.2"
+  s.add_dependency "hashie"
   s.add_dependency "net-ssh"
   s.add_dependency "httpclient"
   s.add_dependency "godot"


### PR DESCRIPTION
Omniauth-facebook requires hashie ~> 1 and lobot tests seem to pass regardless of hashie version so unversioning seems reasonable.
