### PR TITLE
Add EC2 Security Group to Config

### DIFF
--- a/lib/lobot/cli.rb
+++ b/lib/lobot/cli.rb
@@ -23,9 +23,9 @@ module Lobot
     desc "create", "Create a new Lobot server using EC2"
     def create
       server = amazon.with_key_pair(lobot_config.server_ssh_pubkey) do |keypair_name|
-        amazon.create_security_group("lobot")
-        amazon.open_port("lobot", 22, 443)
-        amazon.launch_server(keypair_name, "lobot", lobot_config.instance_size)
+        amazon.create_security_group(lobot_config.security_group)
+        amazon.open_port(lobot_config.security_group, 22, 443)
+        amazon.launch_server(keypair_name, lobot_config.security_group, lobot_config.instance_size)
       end
       wait_for_server(server)
 

--- a/lib/lobot/config.rb
+++ b/lib/lobot/config.rb
@@ -16,6 +16,7 @@ module Lobot
     property :recipes, :default => ["pivotal_ci::jenkins", "pivotal_ci::limited_travis_ci_environment", "pivotal_ci"]
     property :cookbook_paths, :default => ['./chef/cookbooks/', './chef/travis-cookbooks/ci_environment', './chef/project-cookbooks']
     property :node_attributes, :default => Proc.new { default_node_attributes }
+    property :security_group, :default => 'lobot'
 
     def initialize(attributes = {})
       super

--- a/lib/lobot/configuration_wizard.rb
+++ b/lib/lobot/configuration_wizard.rb
@@ -15,6 +15,7 @@ module Lobot
       prompt_for_github_key
       prompt_for_ssh_key
       prompt_for_aws
+      prompt_for_security_group
       prompt_for_basic_auth
       config.save
       say config.reload.display
@@ -35,6 +36,11 @@ module Lobot
         say("For your AWS Access Key and Secret, see https://aws-portal.amazon.com/gp/aws/developer/account/index.html?ie=UTF8&action=access-key")
         config.aws_key = ask_with_default("Your AWS key", config.aws_key)
         config.aws_secret = ask_with_default("Your AWS secret key", config.aws_secret)
+      end
+
+      def prompt_for_security_group
+        say("What EC2 security group would you like to use?")
+        config.security_group = ask_with_default("lobot", config.security_group)
       end
 
       def prompt_for_basic_auth

--- a/lib/lobot/configuration_wizard.rb
+++ b/lib/lobot/configuration_wizard.rb
@@ -39,8 +39,7 @@ module Lobot
       end
 
       def prompt_for_security_group
-        say("What EC2 security group would you like to use?")
-        config.security_group = ask_with_default("lobot", config.security_group)
+        config.security_group = ask_with_default("What EC2 security group would you like to use?", config.security_group)
       end
 
       def prompt_for_basic_auth

--- a/spec/lib/lobot/cli_spec.rb
+++ b/spec/lib/lobot/cli_spec.rb
@@ -126,6 +126,17 @@ describe Lobot::CLI do
           cli.create
         end
 
+        context "with a custom security group", :slow => false do
+          before { cli.lobot_config.security_group = 'custom_group' }
+
+          it "launches the instance with the configured security group" do
+            amazon.should_receive(:create_security_group).with('custom_group')
+            amazon.should_receive(:open_port).with('custom_group', anything, anything)
+            amazon.should_receive(:launch_server).with(anything, 'custom_group', anything)
+            cli.create
+          end
+        end
+
         context "with a custom instance size", :slow => false do
           before { cli.lobot_config.instance_size = 'really_big_instance' }
 

--- a/spec/lib/lobot/config_spec.rb
+++ b/spec/lib/lobot/config_spec.rb
@@ -210,6 +210,7 @@ keypair_name: lobot
     its(:recipes) { should == ["pivotal_ci::jenkins", "pivotal_ci::limited_travis_ci_environment", "pivotal_ci"] }
     its(:cookbook_paths) { should == ['./chef/cookbooks/', './chef/travis-cookbooks/ci_environment', './chef/project-cookbooks'] }
     its(:instance_size) { should == 'c1.medium' }
+    its(:security_group) { should == 'lobot'}
 
     context 'when id_rsa exists' do
       before { File.stub(:exists?).and_return(true) }

--- a/spec/lib/lobot/configuration_wizard_spec.rb
+++ b/spec/lib/lobot/configuration_wizard_spec.rb
@@ -77,6 +77,11 @@ describe Lobot::ConfigurationWizard do
       wizard.setup
     end
 
+    it "prompts for security group" do
+      wizard.should_receive(:prompt_for_security_group)
+      wizard.setup
+    end
+
     it "prompts for nginx basic auth credentials" do
       wizard.should_receive(:prompt_for_basic_auth)
       wizard.setup
@@ -152,6 +157,18 @@ describe Lobot::ConfigurationWizard do
 
       wizard.config.aws_key.should == "aws-key"
       wizard.config.aws_secret.should == "aws-secret-key"
+    end
+  end
+
+  describe "#prompt_for_security_group" do
+    before { wizard.stub(:say) }
+
+    it "reads in security group" do
+      wizard.should_receive(:ask).and_return("lobot")
+
+      wizard.prompt_for_security_group
+
+      wizard.config.security_group.should == "lobot"
     end
   end
 


### PR DESCRIPTION
Added the ability to specify an EC2 security group in `lobot setup`. It defaults to lobot.

This gives the flexibility of using your naming convention or to use a preexisting security group on your account (you could be an IAM user who is restricted from creating security groups).
